### PR TITLE
feat: Change prod connect_url and add staging deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,3 @@ dist-ssr
 # localfiles
 .env.production
 .env
-fly-staging.toml

--- a/fly-production.toml
+++ b/fly-production.toml
@@ -13,7 +13,7 @@ kill_timeout = '5s'
 
 [build]
 [build.args]
-    CONNECT_API_URL = "https://connect.flatpeak.com"
+  CONNECT_API_URL = "https://connect.flatpeak.com"
 
 [env]
   CLOUDWATCH_GROUP_NAME = '/production/app/provider/connect-web-anode'

--- a/fly-staging.toml
+++ b/fly-staging.toml
@@ -1,9 +1,9 @@
-# fly.toml app configuration file generated for connect-web-anode-prod-fp on 2025-10-21T10:26:24+03:00
+# fly.toml app configuration file generated for connect-web-anode-stg-fp on 2025-10-21T10:26:24+03:00
 #
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
 
-app = 'connect-web-anode-prod-fp'
+app = 'connect-web-anode-stg-fp'
 primary_region = 'lhr'
 kill_signal = 'SIGINT'
 kill_timeout = '5s'
@@ -13,11 +13,11 @@ kill_timeout = '5s'
 
 [build]
 [build.args]
-    CONNECT_API_URL = "https://connect.flatpeak.com"
+    CONNECT_API_URL = "https://stg-connect.flatpeak.com"
 
 [env]
-  CLOUDWATCH_GROUP_NAME = '/production/app/provider/connect-web-anode'
-  CONNECT_API_URL = 'https://connect.flatpeak.com'
+  CLOUDWATCH_GROUP_NAME = '/staging/app/provider/connect-web-anode'
+  CONNECT_API_URL = 'https://stg-connect.flatpeak.com'
 
 [[services]]
   protocol = 'tcp'

--- a/fly-staging.toml
+++ b/fly-staging.toml
@@ -1,8 +1,3 @@
-# fly.toml app configuration file generated for connect-web-anode-stg-fp on 2025-10-21T10:26:24+03:00
-#
-# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
-#
-
 app = 'connect-web-anode-stg-fp'
 primary_region = 'lhr'
 kill_signal = 'SIGINT'
@@ -13,7 +8,7 @@ kill_timeout = '5s'
 
 [build]
 [build.args]
-    CONNECT_API_URL = "https://stg-connect.flatpeak.com"
+  CONNECT_API_URL = "https://stg-connect.flatpeak.com"
 
 [env]
   CLOUDWATCH_GROUP_NAME = '/staging/app/provider/connect-web-anode'


### PR DESCRIPTION
Anode release is active now so we need to point the prod fly app at `https://connect.flatpeak.com`

Also adds the staging deployment.