### PR TITLE
fix: allow negative surcharge values

### DIFF
--- a/src/screens/DynamicViews/MarketSurchargeCapture.tsx
+++ b/src/screens/DynamicViews/MarketSurchargeCapture.tsx
@@ -69,8 +69,8 @@ export const MarketSurchargeCapture = () => {
         </LeadingText>
         <Box rg={16} ai={'center'}>
           <BlockHeading text="Fee per kWh incl. VAT" icon={<CoinsIcon width={24} height={32} />} />
-          <InputRate ref={fixedCostInputRef} name="fixed" defaultValue={action.data.surcharge.fixed} autoFocus={true} prefix={getCurrencySymbol(action.data.currency_code)} useDefault={false} />
-          <InputRate ref={percentCostInputRef} name="percentage" defaultValue={action.data.surcharge.percentage} autoFocus={false} suffix={"%"} useDefault={false} layoutRightOffset={44} />
+          <InputRate ref={fixedCostInputRef} name="fixed" defaultValue={action.data.surcharge.fixed} autoFocus={true} prefix={getCurrencySymbol(action.data.currency_code)} useDefault={false} allowNegative={true} />
+          <InputRate ref={percentCostInputRef} name="percentage" defaultValue={action.data.surcharge.percentage} autoFocus={false} suffix={"%"} useDefault={false} layoutRightOffset={44} allowNegative={true} />
           <ButtonBig label={'Reset all additional costs'} type="button" variant={'link'} size={'small'} onClick={handleReset} />
         </Box>
         {Boolean(action.data.regions?.length) && (

--- a/src/shared/ui/InputRate/InputRate.tsx
+++ b/src/shared/ui/InputRate/InputRate.tsx
@@ -10,6 +10,7 @@ type InputRateTimeProps = {
     suffix?: string;
     useDefault?: boolean;
     layoutRightOffset?: number;
+    allowNegative?: boolean;
 } & InputHTMLAttributes<HTMLInputElement>;
 
 export type InputRateHandle = {
@@ -17,7 +18,7 @@ export type InputRateHandle = {
 };
 
 const InputRate = forwardRef<InputRateHandle, InputRateTimeProps>((props, ref) => {
-    const { variant, prefix="", suffix = "", defaultValue, useDefault = true, layoutRightOffset = 0, ...inputAttributes } = props
+    const { variant, prefix="", suffix = "", defaultValue, useDefault = true, layoutRightOffset = 0, allowNegative = false, ...inputAttributes } = props
 
     const [value, setValue] = useState(defaultValue || useDefault ? '0.00' : "");
 
@@ -31,7 +32,8 @@ const InputRate = forwardRef<InputRateHandle, InputRateTimeProps>((props, ref) =
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         let { value } = e.target;
         value = value.replace(/,/g, '.');
-        if (/^\d*\.?\d{0,4}$/.test(value)) {
+        const valuePattern = allowNegative ? /^-?\d*\.?\d{0,4}$/ : /^\d*\.?\d{0,4}$/;
+        if (valuePattern.test(value)) {
             setValue(value);
         }
     };
@@ -43,8 +45,8 @@ const InputRate = forwardRef<InputRateHandle, InputRateTimeProps>((props, ref) =
                   ref={inputRef}
                      className={styles.control}
                      type="text"
-                     pattern="[0-9.,]*"
-                     inputMode="decimal"
+                     pattern={allowNegative ? "-?[0-9.,]*" : "[0-9.,]*"}
+                     inputMode={allowNegative ? "text" : "decimal"}
                      step={0.01}
                      value={value}
                      {...inputAttributes}

--- a/src/shared/ui/InputRate/InputRate.tsx
+++ b/src/shared/ui/InputRate/InputRate.tsx
@@ -46,7 +46,7 @@ const InputRate = forwardRef<InputRateHandle, InputRateTimeProps>((props, ref) =
                      className={styles.control}
                      type="text"
                      pattern={allowNegative ? "-?[0-9.,]*" : "[0-9.,]*"}
-                     inputMode={allowNegative ? "text" : "decimal"}
+                     inputMode={allowNegative ? "numeric" : "decimal"}
                      step={0.01}
                      value={value}
                      {...inputAttributes}


### PR DESCRIPTION
Enable minus-prefixed input in surcharge fixed and percentage fields to support negative additional cost adjustments.

Made-with: Cursor